### PR TITLE
Fix module import on case-sensitive file systems

### DIFF
--- a/VpasModule/15.0.0/VpasModule.psm1
+++ b/VpasModule/15.0.0/VpasModule.psm1
@@ -4,7 +4,15 @@ $folders = 'Classes', 'Includes', 'Internal', 'Private', 'Public', 'Bin'
 foreach ($folder in $folders)
 {
     $root = Join-Path -Path $PSScriptRoot -ChildPath $folder
-    if (Test-Path -Path $root)
+    if (-not (Test-Path -Path $root))
+    {
+        # Resolve folder names case-insensitively for non-Windows file systems.
+        $root = Get-ChildItem -Path $PSScriptRoot -Directory |
+            Where-Object Name -eq $folder |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    if (![String]::IsNullOrEmpty($root) -and (Test-Path -Path $root))
     {
         Write-Verbose -Message "Importing files from [$folder]..."
         $files = Get-ChildItem -Path $root -Filter '*.ps1' -Recurse |
@@ -17,8 +25,19 @@ foreach ($folder in $folders)
     }
 }
 Write-Verbose -Message 'Exporting Public functions...'
-$functions = Get-ChildItem -Path "$PSScriptRoot\Public" -Filter '*.ps1'
-Export-ModuleMember -Function $functions.BaseName -alias *
+$publicRoot = Join-Path -Path $PSScriptRoot -ChildPath 'Public'
+if (-not (Test-Path -Path $publicRoot))
+{
+    # Resolve folder names case-insensitively for non-Windows file systems.
+    $publicRoot = Get-ChildItem -Path $PSScriptRoot -Directory |
+        Where-Object Name -eq 'Public' |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+if (![String]::IsNullOrEmpty($publicRoot) -and (Test-Path -Path $publicRoot))
+{
+    $functions = Get-ChildItem -Path $publicRoot -Filter '*.ps1'
+    Export-ModuleMember -Function $functions.BaseName -alias *
+}
 # SIG # Begin signature block
 # MIIrpgYJKoZIhvcNAQcCoIIrlzCCK5MCAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR


### PR DESCRIPTION
This (tiny fix) fixes module import on Linux/macOS where the file system is case-sensitive.

The module loader looked for `Public` and `Private`, but the repository folders are named `public` and `private`. On Windows this still works, but on Linux PowerShell could not find the folders and exported zero commands.

This change keeps the path behavior first, then falls back to resolving module subfolders without case compat. 

Verified on Ubuntu with PowerShell 7.6.1:
- `Test-ModuleManifest` succeeds
- `Import-Module` succeeds
- module exports 266 commands

Note: I see this script has an Authenticode signature block, so maintainer will need to re-sign it during release.